### PR TITLE
App id title filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,21 @@ spawn-at-startup "niri-float-sticky"
 Usage of niri-float-sticky:
   -allow-moving-to-foreign-monitors
         allow moving to foreign monitors
+  -app-id value
+        only move floating windows with app-id matching given patterns
   -debug
         enable debug logging
+  -title value
+        only move floating windows with title matching this pattern
   -version
         print version and exit
 ```
+
+Notes:
+
+- `-app-id` and `-title` can be provided multiple times to specify different patterns.
+- Each flag accepts regex, so you can also provide multiple patterns in one flag (e.g. `foo|bar`).
+- Internally all patterns are combined into a single regex with alternatives
 
 Example with debug log:
 ```bash

--- a/array-flag/array-flag.go
+++ b/array-flag/array-flag.go
@@ -1,0 +1,15 @@
+// Package arrayflag
+package arrayflag
+
+import "fmt"
+
+type ArrayFlag []string
+
+func (i *ArrayFlag) String() string {
+	return fmt.Sprintf("%v", *i)
+}
+
+func (i *ArrayFlag) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}

--- a/utils/combine-patterns.go
+++ b/utils/combine-patterns.go
@@ -1,0 +1,12 @@
+// Package utils
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+func CombinePatterns[T ~[]string](patterns T) regexp.Regexp {
+	pattern := strings.Join(patterns, "|")
+	return *regexp.MustCompile(pattern)
+}

--- a/utils/combine-patterns_test.go
+++ b/utils/combine-patterns_test.go
@@ -1,0 +1,173 @@
+package utils
+
+import "testing"
+
+func TestCombinePatterns_CompilesAndMatchesAnyAlternative(t *testing.T) {
+	re := CombinePatterns([]string{"foo", "bar"})
+
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"foo", true},
+		{"bar", true},
+		{"xxfooyy", true},
+		{"xxbaryy", true},
+		{"baz", false},
+		{"", false},
+	}
+
+	for _, tc := range cases {
+		if got := re.MatchString(tc.in); got != tc.want {
+			t.Fatalf("MatchString(%q)=%v, want %v (regex=%q)", tc.in, got, tc.want, re.String())
+		}
+	}
+}
+
+func TestCombinePatterns_WorksWithNamedSliceType(t *testing.T) {
+	type ArrayFlag []string
+
+	re := CombinePatterns(ArrayFlag{"cat", "dog"})
+
+	if !re.MatchString("hotdog") {
+		t.Fatalf("expected regex %q to match input %q", re.String(), "hotdog")
+	}
+	if re.MatchString("mouse") {
+		t.Fatalf("expected regex %q to NOT match input %q", re.String(), "mouse")
+	}
+}
+
+func TestCombinePatterns_PreservesRegexMetacharacters(t *testing.T) {
+	// This test documents current behavior: patterns are treated as raw regex,
+	// not literals (no escaping is applied).
+	re := CombinePatterns([]string{`a.*b`, `^hello$`})
+
+	if !re.MatchString("axxxb") {
+		t.Fatalf("expected %q to match %q", re.String(), "axxxb")
+	}
+	if !re.MatchString("hello") {
+		t.Fatalf("expected %q to match %q", re.String(), "hello")
+	}
+	if re.MatchString("hello!") {
+		t.Fatalf("expected %q to NOT match %q", re.String(), "hello!")
+	}
+}
+
+func TestCombinePatterns_EmptyPatternsProducesEmptyRegexWhichMatchesEverything(t *testing.T) {
+	// strings.Join on an empty slice => ""
+	// regexp "" matches at position 0 in any string.
+	re := CombinePatterns([]string{})
+
+	cases := []string{"", "anything", "123"}
+	for _, in := range cases {
+		if !re.MatchString(in) {
+			t.Fatalf("expected empty regex to match %q", in)
+		}
+	}
+}
+
+func TestCombinePatterns_PanicsOnInvalidRegex(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on invalid regex, got none")
+		}
+	}()
+
+	_ = CombinePatterns([]string{"("}) // invalid regex => MustCompile panics
+}
+
+func TestCombinePatterns_ElementContainsAlternative(t *testing.T) {
+	re := CombinePatterns([]string{"foo|bar", "baz"})
+
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"foo", true},
+		{"bar", true},
+		{"baz", true},
+		{"qux", false},
+	}
+
+	for _, tc := range cases {
+		if got := re.MatchString(tc.in); got != tc.want {
+			t.Fatalf(
+				"MatchString(%q)=%v, want %v (regex=%q)",
+				tc.in, got, tc.want, re.String(),
+			)
+		}
+	}
+}
+
+func TestCombinePatterns_MultipleElementsWithAlternatives(t *testing.T) {
+	re := CombinePatterns([]string{
+		"foo|bar",
+		"baz|qux",
+	})
+
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"foo", true},
+		{"bar", true},
+		{"baz", true},
+		{"qux", true},
+		{"nope", false},
+	}
+
+	for _, tc := range cases {
+		if got := re.MatchString(tc.in); got != tc.want {
+			t.Fatalf(
+				"MatchString(%q)=%v, want %v (regex=%q)",
+				tc.in, got, tc.want, re.String(),
+			)
+		}
+	}
+}
+
+func TestCombinePatterns_AlternativePrecedenceIsNotIsolated(t *testing.T) {
+	re := CombinePatterns([]string{
+		"ab|cd",
+		"efg",
+	})
+
+	if !re.MatchString("cd") {
+		t.Fatalf("expected %q to match %q", re.String(), "cd")
+	}
+	if !re.MatchString("efg") {
+		t.Fatalf("expected %q to match %q", re.String(), "efg")
+	}
+	if re.MatchString("def") {
+		t.Fatalf("did not expect %q to match %q", re.String(), "cdef")
+	}
+}
+
+func TestCombinePatterns_AlternativeWithAnchors(t *testing.T) {
+	re := CombinePatterns([]string{
+		"^foo|bar$",
+		"baz",
+	})
+
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"foo", true}, // ^foo
+		{"bar", true}, // bar$
+		{"baz", true},
+		{"foobar", true},   // matches ^foo
+		{"xxbar", true},    // matches bar$
+		{"xxbazxx", true},  // contains baz
+		{"xxbarxx", false}, // bar not at the end
+	}
+
+	for _, tc := range cases {
+		if got := re.MatchString(tc.in); got != tc.want {
+			t.Fatalf(
+				"MatchString(%q)=%v, want %v (regex=%q)",
+				tc.in, got, tc.want, re.String(),
+			)
+		}
+	}
+}


### PR DESCRIPTION
Adds -app-id and -title flags to only follow specific floating windows via regex patterns instead of making all floating windows sticky.