### PR TITLE
Add manual sticky control and IPC interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Usage of niri-float-sticky:
         only move floating windows with app-id matching given patterns
   -debug
         enable debug logging
+  -disable-auto-stick
+        disable auto sticking for all windows
+  -ipc string
+        send IPC command to daemon: set_sticky, unset_sticky, toggle_sticky
   -title value
         only move floating windows with title matching this pattern
   -version
@@ -69,6 +73,68 @@ cat <<EOF | sudo tee /etc/logrotate.d/niri-float-sticky >/dev/null
 }
 EOF
 ```
+
+
+### IPC
+
+`niri-float-sticky` exposes a simple UNIX socket IPC interface to control window stickiness at runtime.
+
+The daemon creates a socket at:
+
+```
+$XDG_RUNTIME_DIR/niri-float-sticky.sock
+```
+
+This allows external commands (for example, keybindings) to toggle stickiness of the currently focused window.
+
+### How It Works
+
+The binary has two modes:
+
+1. **Daemon mode** (default)
+   Runs the event loop and listens for IPC commands.
+
+2. **Client mode** (`-ipc`)
+   Sends a command to the running daemon and exits immediately.
+
+
+### Available IPC Commands
+
+```bash
+niri-float-sticky -ipc set_sticky
+niri-float-sticky -ipc unset_sticky
+niri-float-sticky -ipc toggle_sticky
+```
+
+* `set_sticky` — force window to be sticky
+* `unset_sticky` — remove manual override
+* `toggle_sticky` — toggle sticky state
+
+
+
+### Example: Keybinding in niri
+
+You can bind stickiness toggling to a key:
+
+```
+binds {
+    Mod+G { 
+        spawn "niri-float-sticky" "-ipc" "toggle_sticky"; 
+    }
+}
+```
+
+### Implementation Details
+
+The IPC protocol uses a JSON message over a UNIX domain socket:
+
+```json
+{
+  "action": "toggle_sticky",
+  "window_id": 123456
+}
+```
+
 
 ## Contributing
 

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -1,0 +1,25 @@
+package ipc
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+)
+
+func SendRequest(c Command) error {
+	conn, err := net.Dial("unix", SocketPath())
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	data, err := json.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(conn, "%s\n", data); err != nil {
+		return fmt.Errorf("failed to write JSON to socket: %w", err)
+	}
+	return nil
+}

--- a/ipc/client.go
+++ b/ipc/client.go
@@ -7,7 +7,11 @@ import (
 )
 
 func SendRequest(c Command) error {
-	conn, err := net.Dial("unix", SocketPath())
+	socketPath, err := SocketPath()
+	if err != nil {
+		return err
+	}
+	conn, err := net.Dial("unix", socketPath)
 	if err != nil {
 		return err
 	}

--- a/ipc/ipc.go
+++ b/ipc/ipc.go
@@ -1,0 +1,53 @@
+package ipc
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type Command struct {
+	Action   string `json:"action"`
+	WindowID uint64 `json:"window_id"`
+}
+
+func SocketPath() string {
+	return filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "niri-float-sticky.sock")
+}
+
+func StartIPC(cmdChan chan<- Command) {
+	socketPath := SocketPath()
+	_ = os.Remove(socketPath)
+
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				continue
+			}
+
+			go handleConn(conn, cmdChan)
+		}
+	}()
+}
+
+func handleConn(c net.Conn, cmdChan chan<- Command) {
+	defer c.Close()
+	var req Command
+	decoder := json.NewDecoder(io.LimitReader(c, 512))
+	if err := decoder.Decode(&req); err != nil {
+		log.Errorf("failed to handle connection: %v", err)
+		return
+	}
+
+	cmdChan <- req
+}

--- a/main.go
+++ b/main.go
@@ -45,16 +45,19 @@ func sendCommand(ipcCmd string) error {
 }
 
 func main() {
-	var debug, showVersion, allowForeignMonitors bool
+	var debug, showVersion, allowForeignMonitors, disableAutoStick bool
 	var appIds, titles arrayflag.ArrayFlag
 	var ipcCmd string
 	flag.StringVar(&ipcCmd, "ipc", "", "send IPC command to daemon: set_sticky, unset_sticky, toggle_sticky")
+	flag.BoolVar(&disableAutoStick, "disable-auto-stick", false, "disable auto sticking for all windows")
 	flag.BoolVar(&debug, "debug", false, "enable debug logging")
 	flag.BoolVar(&showVersion, "version", false, "print version and exit")
 	flag.BoolVar(&allowForeignMonitors, "allow-moving-to-foreign-monitors", false, "allow moving to foreign monitors")
 	flag.Var(&appIds, "app-id", "only move floating windows with app-id matching given patterns")
 	flag.Var(&titles, "title", "only move floating windows with title matching this pattern")
 	flag.Parse()
+
+	autoStickEnabled := !disableAutoStick
 
 	if showVersion {
 		fmt.Println(version)
@@ -86,7 +89,7 @@ func main() {
 	workspacesMonitorMap := make(map[uint64]string)
 	windowsMonitorMap := make(map[uint64]string)
 
-	windowsMgr := windows.NewWindowsManager()
+	windowsMgr := windows.NewWindowsManager(autoStickEnabled)
 	cmdChan := make(chan ipc.Command)
 	ipc.StartIPC(cmdChan)
 

--- a/niri-windows/list.go
+++ b/niri-windows/list.go
@@ -2,6 +2,8 @@
 package niriwindows
 
 import (
+	"fmt"
+
 	"github.com/probeldev/niri-float-sticky/bash"
 )
 
@@ -31,4 +33,17 @@ func GetFloatWindows() ([]Window, error) {
 	}
 
 	return response, nil
+}
+
+func GetFocusedWindow() (Window, error) {
+	windows, err := GetWindowsList()
+	if err != nil {
+		return Window{}, err
+	}
+	for _, w := range windows {
+		if w.IsFocused {
+			return w, nil
+		}
+	}
+	return Window{}, fmt.Errorf("no focused window found")
 }

--- a/windows/windows-manager.go
+++ b/windows/windows-manager.go
@@ -1,0 +1,53 @@
+package windows
+
+type WindowsManager struct {
+	floatingWindows map[uint64]struct{}
+	manualOverride  map[uint64]bool
+}
+
+func NewWindowsManager() *WindowsManager {
+	return &WindowsManager{
+		floatingWindows: make(map[uint64]struct{}),
+		manualOverride:  make(map[uint64]bool),
+	}
+}
+
+func (wm *WindowsManager) GetSticky() []uint64 {
+	res := make([]uint64, 0, len(wm.floatingWindows))
+	for winId := range wm.floatingWindows {
+		sticky, ok := wm.manualOverride[winId]
+		if !ok || sticky {
+			res = append(res, winId)
+		}
+	}
+	return res
+}
+
+func (wm *WindowsManager) IsSticky(id uint64) bool {
+	if v, ok := wm.manualOverride[id]; ok {
+		return v
+	}
+	_, auto := wm.floatingWindows[id]
+	return auto
+}
+
+func (wm *WindowsManager) SetFloating(id uint64) {
+	wm.floatingWindows[id] = struct{}{}
+}
+
+func (wm *WindowsManager) ResetFloating() {
+	wm.floatingWindows = make(map[uint64]struct{})
+}
+
+func (wm *WindowsManager) SetManual(id uint64, sticky bool) {
+	current := wm.IsSticky(id)
+	if sticky == current {
+		return
+	}
+	wm.manualOverride[id] = sticky
+}
+
+func (wm *WindowsManager) Remove(id uint64) {
+	delete(wm.floatingWindows, id)
+	delete(wm.manualOverride, id)
+}

--- a/windows/windows-manager.go
+++ b/windows/windows-manager.go
@@ -3,20 +3,21 @@ package windows
 type WindowsManager struct {
 	floatingWindows map[uint64]struct{}
 	manualOverride  map[uint64]bool
+	autoStick       bool
 }
 
-func NewWindowsManager() *WindowsManager {
+func NewWindowsManager(autoStick bool) *WindowsManager {
 	return &WindowsManager{
 		floatingWindows: make(map[uint64]struct{}),
 		manualOverride:  make(map[uint64]bool),
+		autoStick:       autoStick,
 	}
 }
 
 func (wm *WindowsManager) GetSticky() []uint64 {
 	res := make([]uint64, 0, len(wm.floatingWindows))
 	for winId := range wm.floatingWindows {
-		sticky, ok := wm.manualOverride[winId]
-		if !ok || sticky {
+		if wm.IsSticky(winId) {
 			res = append(res, winId)
 		}
 	}
@@ -28,7 +29,10 @@ func (wm *WindowsManager) IsSticky(id uint64) bool {
 		return v
 	}
 	_, auto := wm.floatingWindows[id]
-	return auto
+	if auto && wm.autoStick {
+		return true
+	}
+	return false
 }
 
 func (wm *WindowsManager) SetFloating(id uint64) {


### PR DESCRIPTION
This PR adds the ability to manually control control the sticky state of floating windows.

I added flag `-disable-auto-stick` to disable auto-sticking for all floating windows.
With this flag, users can choose to make only selected windows sticky.  If the flag is not used, selected windows can remain non-sticky.

The daemon uses a UNIX socket to control this behavior.  It creates the socket on startup and listens on it.  Once the daemon is running, users can run `niri-float-sticky -ipc <command>` to control the stickiness of the currently focused window.

I also fixed a bug in the `nirisocket` package.  A panic could occur randomly at startup when unmarshalling invalid JSON, and it now seems to work correctly.
